### PR TITLE
Fix parsing of big coordinates

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -137,19 +137,19 @@ function simpleParse(text) {
   const atoms = [];
   for (let i = 0; i < natoms; i += 1) {
     const l = lines[4 + i] || '';
-    const x = parseFloat(l.slice(0, 10));
-    const y = parseFloat(l.slice(10, 20));
-    const z = parseFloat(l.slice(20, 30));
-    const symbol = l.slice(31, 34).trim();
+    const parts = l.trim().split(/\s+/);
+    const x = parseFloat(parts[0]);
+    const y = parseFloat(parts[1]);
+    const z = parseFloat(parts[2]);
+    const symbol = parts[3] ?? '';
     atoms.push({ x, y, z, symbol });
   }
 
   const bonds = [];
   for (let i = 0; i < nbonds; i += 1) {
     const l = lines[4 + natoms + i] || '';
-    const a = Number(l.slice(0, 3));
-    const b = Number(l.slice(3, 6));
-    bonds.push({ beginAtomIdx: a, endAtomIdx: b });
+    const [a, b] = l.trim().split(/\s+/);
+    bonds.push({ beginAtomIdx: Number(a), endAtomIdx: Number(b) });
   }
 
   const props = {};

--- a/test/bigcoords.test.js
+++ b/test/bigcoords.test.js
@@ -1,0 +1,20 @@
+/* eslint-disable import/extensions */
+import { describe, it, expect } from 'vitest'
+import { parseSDF } from '../src/index.js'
+
+const BIG_SDF = `big
+  gen
+
+  1  0  0  0  0  0              0 V2000
+ 1234567890.1234 2345678901.2345 3456789012.3456 C   0  0  0  0  0  0  0  0  0  0  0  0
+M  END
+$$$$`
+
+describe('simpleParse', () => {
+  it('handles coordinates longer than column width', () => {
+    const mol = parseSDF(BIG_SDF)
+    expect(mol.atoms[0].x).toBeCloseTo(1234567890.1234)
+    expect(mol.atoms[0].y).toBeCloseTo(2345678901.2345)
+    expect(mol.atoms[0].z).toBeCloseTo(3456789012.3456)
+  })
+})


### PR DESCRIPTION
## Summary
- improve `simpleParse` logic for atoms/bonds to support long fields
- add regression test covering large coordinate values

## Testing
- `npm test`
- `npm run lint`
- `npm run size`


------
https://chatgpt.com/codex/tasks/task_e_6848920feb2083218dac71a6e214ba88